### PR TITLE
Add object key query alternatives.

### DIFF
--- a/src/Topaz.Test/BasicObjectTests.cs
+++ b/src/Topaz.Test/BasicObjectTests.cs
@@ -55,12 +55,27 @@ model.p1 = a.p1
             Assert.AreEqual(6, values.Count);
             Assert.AreEqual(js, deserialized);
         }
-        
+
         Assert.AreEqual(1, js.a1);
         Assert.AreEqual(2, js.a2);
         Assert.AreEqual(3, js.a3);
         Assert.AreEqual(4, js[new DateTime()]);
         Assert.AreEqual(5, js[null]);
         Assert.IsNull(model.p1);
+    }
+
+    [TestCase]
+    public void TestInQuery()
+    {
+        var engine = new TopazEngine();
+        engine.ExecuteScript("let obj = { a: { b: '123' }}");
+        Assert.That(engine.ExecuteExpression("'b' in obj.a"), Is.True);
+        Assert.That(engine.ExecuteExpression("obj.a.Contains('b')"), Is.True);
+        Assert.That(engine.ExecuteExpression("obj.a.hasOwn('b')"), Is.True);
+        Assert.That(engine.ExecuteExpression("obj.a.hasOwnProperty('b')"), Is.True);
+        Assert.That(engine.ExecuteExpression("'c' in obj.a"), Is.False);
+        Assert.That(engine.ExecuteExpression("obj.a.Contains('c')"), Is.False);
+        Assert.That(engine.ExecuteExpression("obj.a.hasOwn('c')"), Is.False);
+        Assert.That(engine.ExecuteExpression("obj.a.hasOwnProperty('c')"), Is.False);
     }
 }

--- a/src/Topaz.Test/DelegateArgumentConversionTests.cs
+++ b/src/Topaz.Test/DelegateArgumentConversionTests.cs
@@ -111,4 +111,14 @@ model.d = d(9)
         Assert.AreEqual(37, model.c);
         Assert.AreEqual(81, model.d);
     }
+
+    [Test]
+    public void TestLambdaFunction()
+    {
+        var engine = new TopazEngine();
+        bool isCalled = false;
+        engine.SetValue("print", (string text) => { isCalled = true; });
+        engine.ExecuteExpression("print('text')");
+        Assert.IsTrue(isCalled);
+    }
 }

--- a/src/Topaz/API/object/concurrent/ConcurrentJsObject.cs
+++ b/src/Topaz/API/object/concurrent/ConcurrentJsObject.cs
@@ -140,4 +140,15 @@ public partial class ConcurrentJsObject : IJsObject, IDictionary
     {
         return false;
     }
+
+#pragma warning disable IDE1006 // Naming Styles
+    public virtual string toString()
+    {
+        return "[object Object]";
+    }
+
+    public bool hasOwnProperty(object key) => Contains(key);
+
+    public bool hasOwn(object key) => Contains(key);
+#pragma warning restore IDE1006 // Naming Styles
 }

--- a/src/Topaz/API/object/normal/JsObject.cs
+++ b/src/Topaz/API/object/normal/JsObject.cs
@@ -12,7 +12,8 @@ public partial class JsObject : IJsObject, IDictionary
 
     readonly DictionarySlim<string, object> dictionary = new();
 
-    public object this[object key] {
+    public object this[object key]
+    {
         get
         {
             if (key == null)
@@ -45,8 +46,10 @@ public partial class JsObject : IJsObject, IDictionary
         }
     }
 
-    public ICollection Values {
-        get {
+    public ICollection Values
+    {
+        get
+        {
             var list = new List<object>(dictionary.Count);
             foreach (var entry in dictionary)
             {
@@ -158,8 +161,14 @@ public partial class JsObject : IJsObject, IDictionary
         return false;
     }
 
+#pragma warning disable IDE1006 // Naming Styles
     public virtual string toString()
     {
         return "[object Object]";
     }
+
+    public bool hasOwnProperty(object key) => Contains(key);
+
+    public bool hasOwn(object key) => Contains(key);
+#pragma warning restore IDE1006 // Naming Styles
 }

--- a/src/Topaz/AstHandlers/Expressions/BinaryExpressionHandler.cs
+++ b/src/Topaz/AstHandlers/Expressions/BinaryExpressionHandler.cs
@@ -1,5 +1,6 @@
 ﻿using Esprima.Ast;
 using System;
+using System.Collections;
 using System.Threading;
 using Tenray.Topaz.Core;
 using Tenray.Topaz.ErrorHandling;
@@ -221,6 +222,13 @@ internal static partial class BinaryExpressionHandler
         ScriptExecutor scriptExecutor, BinaryOperator @operator,
         object left, object right)
     {
+        if (@operator == BinaryOperator.In)
+        {
+            if (right is IDictionary dic)
+                return dic.Contains(left);
+            Exceptions.ThrowCannotUseInOperatorToSearchForIn(left, right);
+        }
+
         // Try to avoid slow dynamic operator execution by type casting
         if (left is double d1)
         {
@@ -314,12 +322,7 @@ internal static partial class BinaryExpressionHandler
             BinaryOperator.RightShift => allowNumeric ? Convert.ToInt32(left ?? 0) >> Convert.ToInt32(right ?? 0) : 0,
             BinaryOperator.UnsignedRightShift => allowNumeric ? Convert.ToInt32(left ?? 0) >> Convert.ToInt32(right ?? 0) : 0,
             BinaryOperator.InstanceOf => left?.GetType().FullName == right?.ToString(),
-            BinaryOperator.In =>
-                JavascriptTypeUtility.HasObjectMethod(right, "ContainsKey") ?
-                    right.ContainsKey(left) :
-                JavascriptTypeUtility.HasObjectMethod(right, "Contains") ?
-                    right.Contains(left) :
-                    Exceptions.ThrowCannotUseInOperatorToSearchForIn(left, right),
+            BinaryOperator.In => Exceptions.ThrowCannotUseInOperatorToSearchForIn(left, right),
             BinaryOperator.LogicalAnd =>
                 JavascriptTypeUtility.AndLogicalOperator(left, right),
             BinaryOperator.LogicalOr =>


### PR DESCRIPTION
Topaz JsObjects are IDictionary instances and querying the keys using the Contains method is already possible.
In addition, the following object key query alternatives are added.
```js
obj.hasOwn(key)
obj.hasOwnProperty(key)
key in obj
```